### PR TITLE
Implement Availability Endpoints

### DIFF
--- a/backend/src/common/interfaces.ts
+++ b/backend/src/common/interfaces.ts
@@ -1,4 +1,4 @@
-export type Availability = {
+export interface Availability {
   day: day_of_week;
   start_time: string; // MySQL uses TIME type, example: '11:12' is recognized as '11:12:00'
   end_time: string;

--- a/backend/src/common/types.ts
+++ b/backend/src/common/types.ts
@@ -1,4 +1,4 @@
-export interface Availability {
+export type Availability = {
   day: day_of_week;
   start_time: string; // MySQL uses TIME type, example: '11:12' is recognized as '11:12:00'
   end_time: string;

--- a/backend/src/common/types.ts
+++ b/backend/src/common/types.ts
@@ -2,6 +2,7 @@ export interface Availability {
   day: day_of_week;
   start_time: string; // MySQL uses TIME type, example: '11:12' is recognized as '11:12:00'
   end_time: string;
+  availability_id?: string;
 }
 
 enum day_of_week {

--- a/backend/src/common/types.ts
+++ b/backend/src/common/types.ts
@@ -1,0 +1,15 @@
+export interface Availability {
+  day: day_of_week;
+  start_time: string; // MySQL uses TIME type, example: '11:12' is recognized as '11:12:00'
+  end_time: string;
+}
+
+enum day_of_week {
+  Monday = 1,
+  Tuesday,
+  Wednesday,
+  Thursday,
+  Friday,
+  Saturday,
+  Sunday
+}

--- a/backend/src/controllers/availabilityController.ts
+++ b/backend/src/controllers/availabilityController.ts
@@ -12,7 +12,7 @@ async function getAvailabilities(req: Request, res: Response) {
         res.status(200).json(availabilities);
     } catch (error) {
         return res.status(500).json({
-            error: `Internal server error: ${error}`
+            error: `Internal server error: ${JSON.stringify(error)}`
         });
     }
 }
@@ -33,7 +33,7 @@ async function getAvailabilityByVolunteerId(req: Request, res: Response) {
         res.status(200).json(availability);
     } catch (error) {
         return res.status(500).json({
-            error: `Internal server error: ${error}`
+            error: `Internal server error: ${JSON.stringify(error)}`
         });
     }
 }
@@ -81,14 +81,42 @@ async function setAvailabilityByVolunteerId(req: Request, res: Response) {
         res.status(200).json(result);
     } catch (error) {
         return res.status(500).json({
-            error: `Internal server error: ${error}`
+            error: `Internal server error: ${JSON.stringify(error)}`
         })
     }
 }
 
+async function updateAvailabilityByVolunteerId(req: Request, res: Response) {
+    // console.log("DEBUG: updateAvailabilityByVolunteerId");
+
+    const { volunteer_id } = req.params;
+    const availabilities: Availability[] = req.body;
+
+    if (!volunteer_id) {
+        return res.status(400).json({
+            error: "Missing required parameter: 'volunteer_id'"
+        });
+    }
+
+    if (!isValidAvailabilities(availabilities)) {
+        return res.status(400).json({
+            error: "Invalid availability data"
+        });
+    }
+
+    try {
+        const result = await availabilityModel.updateAvailabilityByVolunteerId(volunteer_id, availabilities);
+        res.status(200).json(result);
+    } catch (error) {
+        return res.status(500).json({
+            error: `Internal server error: ${JSON.stringify(error)}`
+        });
+    }
+}
 
 export {
     getAvailabilities,
     getAvailabilityByVolunteerId,
-    setAvailabilityByVolunteerId
+    setAvailabilityByVolunteerId,
+    updateAvailabilityByVolunteerId
 };

--- a/backend/src/controllers/availabilityController.ts
+++ b/backend/src/controllers/availabilityController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import AvailabilityModel from '../models/availabilityModel.js';
-import { Availability } from '../common/types.js';
+import { Availability } from '../common/interfaces.js';
 
 const availabilityModel = new AvailabilityModel();
 

--- a/backend/src/controllers/availabilityController.ts
+++ b/backend/src/controllers/availabilityController.ts
@@ -1,0 +1,94 @@
+import { Request, Response } from 'express';
+import AvailabilityModel from '../models/availabilityModel.js';
+import { Availability } from '../common/types.js';
+
+const availabilityModel = new AvailabilityModel();
+
+async function getAvailabilities(req: Request, res: Response) {
+    // console.log("DEBUG: getAvailabilities");
+
+    try {
+        const availabilities = await availabilityModel.getAvailabilities();
+        res.status(200).json(availabilities);
+    } catch (error) {
+        return res.status(500).json({
+            error: `Internal server error: ${error}`
+        });
+    }
+}
+
+async function getAvailabilityByVolunteerId(req: Request, res: Response) {
+    // console.log("DEBUG: getAvailabilityByVolunteerId");
+
+    const { volunteer_id } = req.params;
+
+    if (!volunteer_id) {
+        return res.status(400).json({
+            error: "Missing required parameter: 'volunteer_id'"
+        });
+    }
+
+    try {
+        const availability = await availabilityModel.getAvailabilityByVolunteerId(volunteer_id);
+        res.status(200).json(availability);
+    } catch (error) {
+        return res.status(500).json({
+            error: `Internal server error: ${error}`
+        });
+    }
+}
+
+function isValidAvailabilities(data: any): data is Availability[] {
+    return Array.isArray(data) && data.every((availability) => {
+        return (
+            // Validate its day is a number between 1 and 7
+            typeof availability.day === "number" &&
+            (availability.day >= 1 && availability.day <= 7) &&
+
+            // Validate its start_time is a string between 00:00 and 23:59
+            typeof availability.start_time === "string" &&
+            availability.start_time.match(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/) &&
+
+            // Validate its end_time is a string between 00:00 and 23:59
+            typeof availability.end_time === "string" &&
+            availability.end_time.match(/^([01]?[0-9]|2[0-3]):[0-5][0-9]$/)
+
+            // TODO: May need to validate start_time < end_time
+        )
+    });
+}
+
+async function setAvailabilityByVolunteerId(req: Request, res: Response) {
+    // console.log("DEBUG: setAvailabilityByVolunteerId");
+
+    const { volunteer_id } = req.params;
+    const availabilities: Availability[] = req.body;
+
+    if (!volunteer_id) {
+        return res.status(400).json({
+            error: "Missing required parameter: 'volunteer_id'"
+        });
+    }
+
+    if (!isValidAvailabilities(availabilities)) {
+        return res.status(400).json({
+            error: "Invalid availability data"
+        });
+    }
+
+    try {
+        const result = await availabilityModel.setAvailabilityByVolunteerId(volunteer_id, availabilities);
+        res.status(200).json(result);
+    } catch (error) {
+        return res.status(500).json({
+            error: `Internal server error: ${error}`
+        })
+    }
+}
+
+
+export {
+    getAvailabilities,
+    getAvailabilityByVolunteerId,
+    setAvailabilityByVolunteerId
+};

--- a/backend/src/controllers/instructorController.ts
+++ b/backend/src/controllers/instructorController.ts
@@ -1,29 +1,29 @@
 import { Request, Response } from 'express';
-import { Instructor } from '../common/types.js';
+import { Instructor } from '../common/interfaces.js';
 import InstructorModel from '../models/instructorModel.js';
 
 const instructorModel = new InstructorModel();
 
-async function getInstructors(req: Request, res: Response) {  
+async function getInstructors(req: Request, res: Response) {
     try {
         const instructors = await instructorModel.getInstructors();
         res.status(200).json(instructors);
     } catch (error: any) {
         return res.status(error.status).json({
-        error: `${error.message}`
+            error: `${error.message}`
         });
     }
 }
 
 async function getInstructorById(req: Request, res: Response) {
     const { instructor_id } = req.params;
-    
+
     if (!instructor_id) {
         return res.status(400).json({
             error: "Missing required parameter: 'instructor_id'"
         });
     }
-    
+
     try {
         const instructor = await instructorModel.getInstructorById(instructor_id);
         res.status(200).json(instructor);
@@ -36,14 +36,14 @@ async function getInstructorById(req: Request, res: Response) {
 
 async function insertInstructor(req: Request, res: Response) {
     const instructor: Instructor = req.body;
-    
+
     const { instructor_id, f_name, l_name, email } = instructor;
     if (!instructor_id || !f_name || !l_name || !email) {
         return res.status(400).json({
             error: "Missing required fields. 'instructor_id', 'f_name', 'l_name', and 'email' are required."
         });
     }
-    
+
     try {
         const result = await instructorModel.insertInstructor(instructor);
         res.status(200).json(result);
@@ -54,8 +54,8 @@ async function insertInstructor(req: Request, res: Response) {
     }
 }
 
-export { 
-    getInstructors, 
+export {
+    getInstructors,
     getInstructorById,
     insertInstructor
 };

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,7 +14,7 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cors());
 
-app.get('/', (req: Request, res: Response) =>  {
+app.get('/', (req: Request, res: Response) => {
   res.send({ message: "Hello Team Neuron!" });
 });
 

--- a/backend/src/models/availabilityModel.ts
+++ b/backend/src/models/availabilityModel.ts
@@ -1,5 +1,5 @@
 import connectionPool from "../config/database.js";
-import { Availability } from "../common/types.js";
+import { Availability } from "../common/interfaces.js";
 
 export default class AvailabilityModel {
   getAvailabilities(): Promise<any> {

--- a/backend/src/models/availabilityModel.ts
+++ b/backend/src/models/availabilityModel.ts
@@ -1,0 +1,62 @@
+import connectionPool from "../config/database.js";
+import { Availability } from "../common/types.js";
+
+export default class AvailabilityModel {
+  getAvailabilities(): Promise<any> {
+    return new Promise((resolve, reject) => {
+      const query = "SELECT * FROM availability";
+
+      connectionPool.query(query, [], (error: any, results: any) => {
+        if (error) {
+          return reject(
+            `An error occurred while executing the query: ${error}`
+          );
+        }
+
+        resolve(results);
+      });
+    });
+  }
+
+  getAvailabilityByVolunteerId(volunteer_id: string): Promise<any> {
+    return new Promise((resolve, reject) => {
+      const query = "SELECT * FROM availability WHERE fk_volunteer_id = ?";
+      const values = [volunteer_id];
+
+      connectionPool.query(query, values, (error: any, results: any) => {
+        if (error) {
+          return reject(
+            `An error occurred while executing the query: ${error}`
+          );
+        }
+
+        if (results.length == 0) {
+          return reject("No availability found under the given ID");
+        }
+
+        resolve(results);
+      });
+    });
+  }
+
+  setAvailabilityByVolunteerId(volunteer_id: string, availabilities: Availability[]): Promise<any> {
+    return new Promise((resolve, reject) => {
+      const query = `INSERT INTO availability (fk_volunteer_id, day_of_week, start_time, end_time) VALUES ?`;
+      const values = availabilities.map((availability) => [
+        volunteer_id,
+        availability.day,
+        availability.start_time,
+        availability.end_time,
+      ]);
+
+      connectionPool.query(query, [values], (error: any, results: any) => {
+        if (error) {
+          return reject(`An error occurred while executing the query: ${error}`);
+        }
+        resolve(results);
+      });
+    });
+  }
+
+  // TODO: updateAvailability
+}

--- a/backend/src/models/availabilityModel.ts
+++ b/backend/src/models/availabilityModel.ts
@@ -72,7 +72,7 @@ export default class AvailabilityModel {
     return new Promise(async (resolve, reject) => {
       try {
 
-        // Get exisitng availabilities and conform them to our interface
+        // Get exisitng availabilities and conform them to our Availability type
         const existingAvailabilities = (await this.getAvailabilityByVolunteerId(volunteer_id))
           .map((availability: any) => ({
             day: availability.day_of_week,

--- a/backend/src/models/instructorModel.ts
+++ b/backend/src/models/instructorModel.ts
@@ -1,67 +1,68 @@
 import connectionPool from '../config/database.js';
-import { Instructor } from '../common/types.js';
+import { Instructor } from '../common/interfaces.js';
 
 // Instructor model
 export default class InstructorModel {
 
- getInstructors(): Promise<any> {
-   return new Promise((resolve, reject) => {
-     const query = `SELECT * FROM instructors`;
+  getInstructors(): Promise<any> {
+    return new Promise((resolve, reject) => {
+      const query = `SELECT * FROM instructors`;
 
-     connectionPool.query(query, [], (error: any, results: any) => {
-       if (error) {reject({
-        status: 500,
-        message: `An error occurred while executing the query: ${error}`,
-        });
-       }
-       resolve(results);
-     });
-   });
- }
+      connectionPool.query(query, [], (error: any, results: any) => {
+        if (error) {
+          reject({
+            status: 500,
+            message: `An error occurred while executing the query: ${error}`,
+          });
+        }
+        resolve(results);
+      });
+    });
+  }
 
- getInstructorById(instructor_id: string): Promise<any> {
-  return new Promise((resolve, reject) => {
+  getInstructorById(instructor_id: string): Promise<any> {
+    return new Promise((resolve, reject) => {
       const query = "SELECT * FROM instructors WHERE instructor_id = ?";
       const values = [instructor_id];
 
       connectionPool.query(query, values, (error: any, results: any) => {
-          if (error) {
-            reject({
-              status: 500,
-              message: `An error occurred while executing the query: ${error}`,
+        if (error) {
+          reject({
+            status: 500,
+            message: `An error occurred while executing the query: ${error}`,
           });
-          }
-          if (results.length == 0) {
-            reject({
-              status: 400,
-              message: `No instructor found under the given ID: ${instructor_id}`,
-            });
-          }
-          resolve(results[0]);
+        }
+        if (results.length == 0) {
+          reject({
+            status: 400,
+            message: `No instructor found under the given ID: ${instructor_id}`,
+          });
+        }
+        resolve(results[0]);
       });
-  });
-};
+    });
+  };
 
-insertInstructor(instructor: Instructor): Promise<any> {
-  return new Promise((resolve, reject) => {
+  insertInstructor(instructor: Instructor): Promise<any> {
+    return new Promise((resolve, reject) => {
       const query =
-          "INSERT INTO instructors (instructor_id, f_name, l_name, email) VALUES (?, ?, ?, ?)";
+        "INSERT INTO instructors (instructor_id, f_name, l_name, email) VALUES (?, ?, ?, ?)";
       const values = [
-          instructor.instructor_id,
-          instructor.f_name,
-          instructor.l_name,
-          instructor.email
+        instructor.instructor_id,
+        instructor.f_name,
+        instructor.l_name,
+        instructor.email
       ];
 
       connectionPool.query(query, values, (error: any, results: any) => {
-          if (error) {
-              return reject({
-                  status: 500,
-                  message: `An error occurred while executing the query: ${error}`,
-              });
-          }
-          resolve(results);
+        if (error) {
+          return reject({
+            status: 500,
+            message: `An error occurred while executing the query: ${error}`,
+          });
+        }
+        resolve(results);
       });
-  });
-};
+    });
+  };
 }

--- a/backend/src/routes/volunteerRoutes.ts
+++ b/backend/src/routes/volunteerRoutes.ts
@@ -9,7 +9,8 @@ import {
 import {
     getAvailabilities,
     getAvailabilityByVolunteerId,
-    setAvailabilityByVolunteerId
+    setAvailabilityByVolunteerId,
+    updateAvailabilityByVolunteerId
 } from '../controllers/availabilityController.js';
 
 const router = Router();
@@ -25,6 +26,9 @@ router.get('/availability/:volunteer_id', (req: Request, res: Response) => { get
 
 // set availability for a volunteer
 router.post('/availability/:volunteer_id', (req: Request, res: Response) => { setAvailabilityByVolunteerId(req, res) });
+
+// update availability for a volunteer
+router.put('/availability/:volunteer_id', (req: Request, res: Response) => { updateAvailabilityByVolunteerId(req, res) });
 
 // get volunteer profile by id
 router.get('/:volunteer_id', (req: Request, res: Response) => { getVolunteerById(req, res) });

--- a/backend/src/routes/volunteerRoutes.ts
+++ b/backend/src/routes/volunteerRoutes.ts
@@ -1,20 +1,35 @@
 import { Router, Request, Response } from 'express';
 
-import { 
-    getVolunteerById, 
-    getVolunteers, 
-    updateVolunteer 
+import {
+    getVolunteerById,
+    getVolunteers,
+    updateVolunteer
 } from '../controllers/volunteerController.js';
 
-const router = Router();
+import {
+    getAvailabilities,
+    getAvailabilityByVolunteerId,
+    setAvailabilityByVolunteerId
+} from '../controllers/availabilityController.js';
 
-// get volunteer profile by id
-router.get('/volunteer/:volunteer_id', (req: Request, res: Response) => { getVolunteerById(req, res) });
+const router = Router();
 
 // get all volunteers
 router.get('/volunteers', (req: Request, res: Response) => { getVolunteers(req, res) });
 
+// get all availabilities
+router.get('/availabilities', (req: Request, res: Response) => { getAvailabilities(req, res) });
+
+// get availability for a volunteer
+router.get('/availability/:volunteer_id', (req: Request, res: Response) => { getAvailabilityByVolunteerId(req, res) });
+
+// set availability for a volunteer
+router.post('/availability/:volunteer_id', (req: Request, res: Response) => { setAvailabilityByVolunteerId(req, res) });
+
+// get volunteer profile by id
+router.get('/:volunteer_id', (req: Request, res: Response) => { getVolunteerById(req, res) });
+
 // update volunteer profile
-router.put('/volunteer/:volunteer_id', (req: Request, res: Response) => { updateVolunteer(req, res) });
+router.put('/:volunteer_id', (req: Request, res: Response) => { updateVolunteer(req, res) });
 
 export default router;


### PR DESCRIPTION
Created `availability` endpoints:
- Built off the `volunteer` routes from #5 
    - Updated the `volunteer` routes to reduce redundancy, e.g. `/volunteer/volunteer/<volunteer_id>` to `/volunteer/<volunteer_id>`
- Added GET `/volunteer/availabilities/` to get all availability records
- Added GET `/volunteer/availability/<volunteer id>` to get availability records associated to one volunteer
- Added POST `/volunteer/availability/<volunteer id>` to set 1+ availability records to one volunteer
  - Includes availability data type (in `src/common/types.ts`) and validation
  - Example:
    - ```json
      [
        {
          "day": 1,
          "start_time": "00:00",
          "end_time": "17:00"
        }
      ]
      ```
    - `day` is a number between `1-7` where `1` corresponds to Monday
    - `start_time` and `end_time` are strings in the format `HH:mm`, ranging from `00:00` to `23:59`
    - `availability_id` is optional -- It is not actually used when setting availability but is used to track which Availability objects are to be removed
- Added PUT `/volunteer/availability/<volunteer id>` to update availabilities
  - FE should send all availabilities from the update
  - Update will skip identical availabilities, only adding new availabilities
  - Update will also remove old availabilities that are no longer present