### PR TITLE
format shift time to 12 hour, display

### DIFF
--- a/frontend/src/components/DetailsPanel/index.js
+++ b/frontend/src/components/DetailsPanel/index.js
@@ -146,7 +146,10 @@ function DetailsPanel({ classId, classList, setClassId, children, dynamicShiftbu
       <div className="panel-container" style={{ width: panelWidth }}>
         <div className="panel-header">
           {shiftDetails ? (
-              <span>{dayjs(shiftDetails.shift_date).format('YYYY-MM-DD')}</span>
+              <span>
+                <div>{dayjs(shiftDetails.start_time, 'HH:mm').format('h:mm A')} - {dayjs(shiftDetails.end_time, 'HH:mm').format('h:mm A')}</div>
+                <div>{dayjs(shiftDetails.shift_date).format('dddd, MMMM D')}</div>
+              </span>
           ) : (
               renderSchedules()
           )}


### PR DESCRIPTION
- called `shiftDetails.start_time` and `shiftDetails.end_time`
- Formatted to 12 hour time
<img width="1440" alt="Screen Shot 2025-01-29 at 6 58 06 PM" src="https://github.com/user-attachments/assets/3e72022b-4dd5-4b31-b84b-7b5459e8810c" />
