### PR TITLE
Char limits + layout improvements in admin class form

### DIFF
--- a/database/init/createTables.sql
+++ b/database/init/createTables.sql
@@ -53,7 +53,7 @@ create table class (
 	class_id INT PRIMARY KEY AUTO_INCREMENT,
     fk_image_id CHAR(36),
     class_name VARCHAR(64) NOT NULL,
-    instructions VARCHAR(150),
+    instructions VARCHAR(3000),
     zoom_link VARCHAR(3000) NOT NULL,
     start_date DATE NOT NULL,
     end_date DATE NOT NULL,

--- a/frontend/src/components/AdminClassForm/index.css
+++ b/frontend/src/components/AdminClassForm/index.css
@@ -50,11 +50,6 @@
     height: 42px;
 }
 
-.class-form-input[type="date"], .class-form-input[type="time"] {
-    font-family: var(--font-primary);
-    font-size: 14px;
-}
-
 .invalid-message {
     align-self: stretch;
     text-align: right;
@@ -74,25 +69,11 @@
     align-items: baseline;
 }
 
-@media screen and (max-width: 900px) {
-    .input-row {
-        flex-direction: column;
-    }
-}
-
 .flex-input {
     display: flex;
     width: 100%;
     align-items: center;
     gap: 16px;
-}
-
-@media screen and (max-width: 600px) {
-    .category-input {
-        flex-direction: column;
-        gap: 8px;
-        align-items: start;
-    }
 }
 
 .class-form-label {
@@ -111,11 +92,11 @@
     box-sizing: border-box;
 }
 
-.select-icon {
+.select-dropdown-icon {
     margin: 0;
     padding: 0;
     position: absolute;
-    right: 10px;
+    right: 16px;
     top: 50%;
     transform: translateY(-50%);
     cursor: pointer;
@@ -130,6 +111,7 @@
     border: 1px solid #ccc;
     border-radius: 8px;
     width: 100%;
+    height: fit-content;
     min-width: fit-content;
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
@@ -154,6 +136,7 @@
 }
 
 .flex-col-input {
+    width: 100%;
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -165,8 +148,7 @@
 }
 
 .class-form-textarea {
-    flex: 1;
-    align-self: stretch;
+    height: 100%;
     min-height: 18px;
     max-height: 400px;
     resize: vertical;
@@ -265,7 +247,7 @@ textarea:focus {
     gap: 20px;
 }
 
-.days-input {
+.days-input-select {
     width: 100%;
     display: flex;
     flex-direction: column;
@@ -438,4 +420,46 @@ textarea:focus {
 .submit-button:disabled {
     cursor: default;
     background-color: #808080;
+}
+
+@media screen and (max-width: 900px) {
+    .input-row {
+        flex-direction: column;
+    }
+}
+
+@media screen and (max-width: 1040px) {
+    .days-input-select {
+        display: none;
+    }
+    .days-input-dropdown {
+        display: flex;
+    }
+}
+
+@media screen and (min-width: 1041px) {
+    .days-input-select {
+        display: flex;
+    }
+    .days-input-dropdown {
+        display: none;
+    }
+}
+
+@media screen and (max-width: 600px) {
+    .category-input {
+        flex-direction: column;
+        gap: 8px;
+        align-items: start;
+    }
+
+    .flex-input {
+        flex-direction: column;
+        gap: 8px;
+        align-items: start;
+    }
+
+    .volunteer-item {
+        white-space: wrap;
+    }
 }

--- a/frontend/src/components/AdminClassForm/index.css
+++ b/frontend/src/components/AdminClassForm/index.css
@@ -1,10 +1,17 @@
 .class-form {
-    width: stretch;
+    width: 100%;
     height: fit-content;
 }
 
+.form-body {
+    font-family: var(--font-primary);
+    font-size: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px
+}
+
 .form-block {
-    width: stretch;
     height: fit-content;
     display: flex;
     flex-direction: column;
@@ -29,32 +36,27 @@
     font-family: var(--font-secondary);
 }
 
-.form-body {
-    width: stretch;
-    font-family: var(--font-primary);
-    font-size: 14px;
-    display: flex;
-    flex-direction: column;
-    gap: 24px
-}
-
 .class-form-input {
     font-family: var(--font-primary);
-    width: stretch;
+    flex: 1;
+    align-self: stretch;
     border: 1px solid #ccc;
     border-radius: 8px;
     font-size: 14px;
     padding: 12px 16px;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    height: 42px;
 }
 
 .class-form-input[type="date"], .class-form-input[type="time"] {
     font-family: var(--font-primary);
     font-size: 14px;
-    width: stretch;
 }
 
 .invalid-message {
-    width: stretch;
+    align-self: stretch;
     text-align: right;
     color: #FF0000;
     margin-top: 4px;
@@ -68,23 +70,20 @@
 .input-row {
     display: flex;
     gap: 20px;
-    width: stretch;
-}
-
-.categories-row {
+    width: 100%;
     align-items: baseline;
 }
 
 @media screen and (max-width: 900px) {
     .input-row {
-        flex-wrap: wrap;
+        flex-direction: column;
     }
 }
 
 .flex-input {
     display: flex;
-    width: stretch;
-    align-items: baseline;
+    width: 100%;
+    align-items: center;
     gap: 16px;
 }
 
@@ -105,7 +104,11 @@
 }
 
 .select {
-    width: stretch;
+    flex: 1;
+    align-self: stretch;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 .select-icon {
@@ -126,8 +129,11 @@
     background-color: white;
     border: 1px solid #ccc;
     border-radius: 8px;
-    width: stretch;
+    width: 100%;
     min-width: fit-content;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
     padding: 6px;
     box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
     z-index: 1000;
@@ -148,19 +154,19 @@
 }
 
 .flex-col-input {
-    width: stretch;
     display: flex;
     flex-direction: column;
     gap: 8px;
 }
 
 .description-input {
-    width: stretch;
+    flex: 1;
+    align-self: stretch;
 }
 
 .class-form-textarea {
-    width: stretch;
-    height: stretch;
+    flex: 1;
+    align-self: stretch;
     min-height: 18px;
     max-height: 400px;
     resize: vertical;
@@ -176,7 +182,7 @@ textarea:focus {
 }
 
 .image-input {
-    flex: 1;
+    width: fit-content;
 }
 
 .image-content {
@@ -210,7 +216,6 @@ textarea:focus {
 }
 
 .class-upload-content {
-    width: stretch;
     aspect-ratio: 1 / 1;
     border-radius: 8px;
     border: 2px dashed #D9D9D9;
@@ -245,8 +250,13 @@ textarea:focus {
     display: none;
 }
 
-.error-wrapper {
-    width: stretch;
+.row-error-wrapper {
+    width: 100%;
+}
+
+.element-error-wrapper {
+    flex: 1;
+    align-self: stretch;
 }
 
 .schedules-input {
@@ -256,29 +266,27 @@ textarea:focus {
 }
 
 .days-input {
-    width: stretch;
+    width: 100%;
     display: flex;
     flex-direction: column;
     gap: 8px;
 }
 
 .days-row {
-    width: stretch;
+    width: 100%;
     display: flex;
     box-shadow: 0px 4px 16px 0px #0F11110D;
 }
 
 .day-input {
-    width: stretch;
+    flex: 1;
+    align-self: stretch;
     border: 1px solid #ccc;
     font-size: 14px;
     color: #808080;
     padding: 12px 16px;
     font-family: var(--font-primary);
     background-color: #fff;
-}
-
-.day-input:hover {
     cursor: pointer;
 }
 
@@ -290,6 +298,10 @@ textarea:focus {
 .saturday-input {
     border-top-right-radius: 8px;
     border-bottom-right-radius: 8px;
+}
+
+.volunteers-input {
+    align-items: baseline;
 }
 
 .volunteers-row {

--- a/frontend/src/components/AdminClassForm/index.js
+++ b/frontend/src/components/AdminClassForm/index.js
@@ -73,7 +73,7 @@ const ClassSchema = Yup.object().shape({
         .optional(),
     zoom_link: Yup.string()
         .max(3000, 'Zoom link cannot exceed 3000 characters.')
-        .url('Invalid URL format')
+        .url('Invalid URL format.')
         .optional(),
     start_date: Yup.date().required(inputPrompt),
     end_date: Yup.date()
@@ -352,24 +352,26 @@ function AdminClassForm({ setUpdates }) {
                     <div className="form-block">
                         <h2 className="section-title">General</h2>
                         
-                        <div className="title-input">
-                            <input 
-                                className="class-form-input"
-                                type="text"
-                                placeholder="Enter Title Here"
-                                label="Title"
-                                name="class_name"
-                                value={values.class_name}
-                                onChange={handleChange}
-                                onBlur={handleBlur}
-                                errors={errors}
-                                touched={touched}
-                            />
+                        <div className="row-error-wrapper">
+                            <div className="input-row">
+                                <input 
+                                    className="class-form-input"
+                                    type="text"
+                                    placeholder="Enter Title Here"
+                                    label="Title"
+                                    name="class_name"
+                                    value={values.class_name}
+                                    onChange={handleChange}
+                                    onBlur={handleBlur}
+                                    errors={errors}
+                                    touched={touched}
+                                />
+                            </div>
                             {errors["class_name"] && touched["class_name"] && (
                                 <div className="invalid-message">{errors["class_name"]}</div>
                             )}
                         </div>
-                        <div className="error-wrapper">
+                        <div className="row-error-wrapper">
                             <div className="flex-input">
                                 <label className="class-form-label">
                                     Zoom Link
@@ -391,18 +393,18 @@ function AdminClassForm({ setUpdates }) {
                                 <div className="invalid-message">{errors["zoom_link"]}</div>
                             )}
                         </div>
-                        <div className="input-row categories-row">
-                            <div className="error-wrapper">
+                        <div className="input-row">
+                            <div className="element-error-wrapper">
                                 <div className="flex-input">
                                     <label className="class-form-label">
                                         Category
                                     </label>
                                     <Select
                                         className="select"
+                                        label="Category"
                                         defaultValue={{value: values.category, label: values.category ?? "Select Category"}}
                                         styles={{
                                             control: () => ({
-                                                width: 'stretch',
                                                 padding: '12px 32px 12px 16px',
                                                 borderRadius: '8px',
                                                 border: '1px solid #cccccc',
@@ -411,7 +413,7 @@ function AdminClassForm({ setUpdates }) {
                                             valueContainer: (styles) => ({
                                                 ...styles,
                                                 padding: '0px'
-                                            })
+                                            }), 
                                         }}
                                         options={categories}
                                         isSearchable={false}
@@ -448,7 +450,7 @@ function AdminClassForm({ setUpdates }) {
                                     <div className="invalid-message">{errors["category"]}</div>
                                 )}
                             </div>
-                            <div className="error-wrapper">
+                            <div className="element-error-wrapper">
                                 <div className="flex-input">
                                     <label className="class-form-label">
                                         Class Type
@@ -471,7 +473,7 @@ function AdminClassForm({ setUpdates }) {
                                 )}
                             </div>
                         </div>
-                        <div className="error-wrapper">
+                        <div className="row-error-wrapper">
                             <div className="input-row">
                                 <div className="flex-col-input image-input">
                                     <label className="class-form-label">
@@ -499,6 +501,7 @@ function AdminClassForm({ setUpdates }) {
                                             className="file-input"
                                             id="fileInput" 
                                             type="file" 
+                                            label="Class Image"
                                             accept="image/*" 
                                             onChange={(event) => {
                                                 const targetImage = event.target.files[0];
@@ -524,6 +527,7 @@ function AdminClassForm({ setUpdates }) {
                                         name="instructions"
                                         placeholder="Enter Description Here"
                                         rows="6"
+                                        label="Description"
                                         value={values.instructions}
                                         onChange={handleChange}
                                         onBlur={handleBlur}
@@ -538,7 +542,7 @@ function AdminClassForm({ setUpdates }) {
                             )}
                         </div>
                         <div className="input-row">
-                            <div className="error-wrapper">
+                            <div className="element-error-wrapper">
                                 <div className="flex-input">
                                     <label className="class-form-label">
                                         Start Date
@@ -559,7 +563,7 @@ function AdminClassForm({ setUpdates }) {
                                     <div className="invalid-message">{errors["start_date"]}</div>
                                 )}
                             </div>
-                            <div className="error-wrapper">
+                            <div className="element-error-wrapper">
                                 <div className="flex-input">
                                     <label className="class-form-label">
                                         End Date
@@ -599,6 +603,7 @@ function AdminClassForm({ setUpdates }) {
                                                     <button 
                                                         key={dayIndex}
                                                         type="button"
+                                                        label="Day"
                                                         style={dayIndex === schedule.day ? {
                                                             background: '#F0FAFF',
                                                             border: '1px solid #4385AC',
@@ -625,10 +630,10 @@ function AdminClassForm({ setUpdates }) {
                                             <Select
                                                 className="select"
                                                 placeholder="Select"
+                                                label="Frequency"
                                                 defaultValue={frequencies.find(f => f.value === schedule.frequency)}
                                                 styles={{
                                                     control: () => ({
-                                                        width: 'stretch',
                                                         padding: '12px 32px 12px 16px',
                                                         borderRadius: '8px',
                                                         border: '1px solid #cccccc',
@@ -672,7 +677,7 @@ function AdminClassForm({ setUpdates }) {
                                             </div>
                                         </div>
                                         <div className="input-row">
-                                            <div className="error-wrapper">
+                                            <div className="element-error-wrapper">
                                                 <div className="flex-input">
                                                     <label className="class-form-label">
                                                         From
@@ -690,7 +695,7 @@ function AdminClassForm({ setUpdates }) {
                                                     />
                                                 </div>
                                             </div>
-                                            <div className="error-wrapper">
+                                            <div className="element-error-wrapper">
                                                 <div className="flex-input">
                                                     <label className="class-form-label">
                                                         To
@@ -712,18 +717,18 @@ function AdminClassForm({ setUpdates }) {
                                                 )}
                                             </div>
                                         </div>
-                                        <div className="input-row">
-                                            <div className="error-wrapper">
+                                        <div className="row-error-wrapper">
+                                            <div className="input-row">
                                                 <div className="flex-input">
                                                     <label className="class-form-label">
                                                         Instructor
                                                     </label>
                                                     <Select
                                                         className="select"
+                                                        label="Instructor"
                                                         defaultValue={instructors.find(i => i.value === schedule.fk_instructor_id) || { label: 'Select Instructor', value: null }}
                                                         styles={{
                                                             control: () => ({
-                                                                width: 'stretch',
                                                                 padding: '12px 32px 12px 16px',
                                                                 borderRadius: '8px',
                                                                 border: '1px solid #cccccc',
@@ -774,7 +779,7 @@ function AdminClassForm({ setUpdates }) {
                                             </div>
                                         </div>
                                         <div className="input-row">
-                                            <div className="flex-input">
+                                            <div className="flex-input volunteers-input">
                                                 <label className="class-form-label">
                                                     Volunteers
                                                 </label>
@@ -806,6 +811,7 @@ function AdminClassForm({ setUpdates }) {
                                                                     className="select add-volunteers"
                                                                     defaultValue={{ value: null, label: 'Enter Volunteer Name' }}
                                                                     autoFocus={true}
+                                                                    label="Volunteer"
                                                                     openMenuOnFocus={true}
                                                                     styles={{
                                                                         control: () => ({
@@ -898,7 +904,7 @@ function AdminClassForm({ setUpdates }) {
                                                         <h2 className="delete-popup-title">Delete Schedule</h2>
                                                         <p className="delete-popup-prompt">Delete this schedule from the class?</p>
                                                         <div className="delete-popup-buttons">
-                                                            <button type="button" className="cancel-button" onClick={() => setShowPopup(false)}>
+                                                            <button type="button" className="cancel-delete-button" onClick={() => setShowPopup(false)}>
                                                                 Cancel
                                                             </button>
                                                             <button

--- a/frontend/src/components/AdminClassForm/index.js
+++ b/frontend/src/components/AdminClassForm/index.js
@@ -65,15 +65,24 @@ const classFields = [
 const inputPrompt = "Please fill out this field.";
 
 const ClassSchema = Yup.object().shape({
-    class_name: Yup.string().required(inputPrompt),
-    instructions: Yup.string().optional(),
-    zoom_link: Yup.string().url('Invalid URL format').required(inputPrompt),
+    class_name: Yup.string()
+        .max(64, 'Class title cannot exceed 64 characters.')
+        .required(inputPrompt),
+    instructions: Yup.string()
+        .max(3000, 'Description cannot exceed 3000 characters.')
+        .optional(),
+    zoom_link: Yup.string()
+        .max(3000, 'Zoom link cannot exceed 3000 characters.')
+        .url('Invalid URL format')
+        .optional(),
     start_date: Yup.date().required(inputPrompt),
     end_date: Yup.date()
         .required(inputPrompt)
         .min(Yup.ref('start_date'), 'End date must be after start date.'),
     category: Yup.string().required(inputPrompt),
-    subcategory: Yup.string().optional(),
+    subcategory: Yup.string()
+        .max(64, 'Class type cannot exceed 64 characters.')
+        .optional(),
     schedules: Yup.array()
         .of(
             Yup.object().shape({
@@ -349,22 +358,27 @@ function AdminClassForm({ setUpdates }) {
                                 <div className="invalid-message">{errors["class_name"]}</div>
                             )}
                         </div>
-                        <div className="flex-input">
-                            <label className="class-form-label">
-                                Zoom Link
-                            </label>
-                            <input 
-                                className="class-form-input"
-                                type="url"
-                                placeholder="Enter Zoom Link"
-                                label="Zoom Link"
-                                name="zoom_link"
-                                value={values.zoom_link}
-                                onChange={handleChange}
-                                onBlur={handleBlur}
-                                errors={errors}
-                                touched={touched}
-                            />
+                        <div className="error-wrapper">
+                            <div className="flex-input">
+                                <label className="class-form-label">
+                                    Zoom Link
+                                </label>
+                                <input 
+                                    className="class-form-input"
+                                    type="url"
+                                    placeholder="Enter Zoom Link"
+                                    label="Zoom Link"
+                                    name="zoom_link"
+                                    value={values.zoom_link}
+                                    onChange={handleChange}
+                                    onBlur={handleBlur}
+                                    errors={errors}
+                                    touched={touched}
+                                />
+                            </div>
+                            {errors["zoom_link"] && touched["zoom_link"] && (
+                                <div className="invalid-message">{errors["zoom_link"]}</div>
+                            )}
                         </div>
                         <div className="input-row categories-row">
                             <div className="error-wrapper">
@@ -423,84 +437,94 @@ function AdminClassForm({ setUpdates }) {
                                     <div className="invalid-message">{errors["category"]}</div>
                                 )}
                             </div>
-                            <div className="flex-input">
-                                <label className="class-form-label">
-                                    Class Type
-                                </label>
-                                <input 
-                                    className="class-form-input"
-                                    type="text"
-                                    placeholder="Enter Class Type"
-                                    label="Type"
-                                    name="subcategory"
-                                    value={values.subcategory}
-                                    onChange={handleChange}
-                                    onBlur={handleBlur}
-                                    errors={errors}
-                                    touched={touched}
-                                />
+                            <div className="error-wrapper">
+                                <div className="flex-input">
+                                    <label className="class-form-label">
+                                        Class Type
+                                    </label>
+                                    <input 
+                                        className="class-form-input"
+                                        type="text"
+                                        placeholder="Enter Class Type"
+                                        label="Type"
+                                        name="subcategory"
+                                        value={values.subcategory}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        errors={errors}
+                                        touched={touched}
+                                    />
+                                </div>
+                                {errors["subcategory"] && touched["subcategory"] && (
+                                    <div className="invalid-message">{errors["subcategory"]}</div>
+                                )}
                             </div>
                         </div>
-                        
-                        <div className="input-row">
-                            <div className="flex-col-input image-input">
-                                <label className="class-form-label">
-                                    Class Image
-                                </label>
-                                <div 
-                                    className="image-content"
-                                    onClick={() => {
-                                        document.getElementById('fileInput').click()
-                                    }}
-                                >
-                                    {image && <img
-                                        className="class-image"
-                                        src={image.src}
-                                        alt="Class"
-                                        onError={(e) => {
-                                            console.log(e);
+                        <div className="error-wrapper">
+                            <div className="input-row">
+                                <div className="flex-col-input image-input">
+                                    <label className="class-form-label">
+                                        Class Image
+                                    </label>
+                                    <div 
+                                        className="image-content"
+                                        onClick={() => {
+                                            document.getElementById('fileInput').click()
                                         }}
-                                    />}
-                                    <div className={image ? "class-image-overlay" : "class-upload-content"}>
-                                        <img src={image ? upload_light : upload_dark} alt="Edit Profile" className="upload-icon" />
-                                        <button type="button" className="edit-button">Browse Images</button>
+                                    >
+                                        {image && <img
+                                            className="class-image"
+                                            src={image.src}
+                                            alt="Class"
+                                            onError={(e) => {
+                                                console.log(e);
+                                            }}
+                                        />}
+                                        <div className={image ? "class-image-overlay" : "class-upload-content"}>
+                                            <img src={image ? upload_light : upload_dark} alt="Edit Profile" className="upload-icon" />
+                                            <button type="button" className="edit-button">Browse Images</button>
+                                        </div>
+                                        <input
+                                            className="file-input"
+                                            id="fileInput" 
+                                            type="file" 
+                                            accept="image/*" 
+                                            onChange={(event) => {
+                                                const targetImage = event.target.files[0];
+                                                const reader = new FileReader();
+                                                reader.onload = () => {
+                                                    setImage({
+                                                        src: reader.result,
+                                                        blob: targetImage
+                                                    });
+                                                };
+                                                reader.readAsDataURL(targetImage);
+                                            }} 
+                                        />
+                                        
                                     </div>
-                                    <input
-                                        className="file-input"
-                                        id="fileInput" 
-                                        type="file" 
-                                        accept="image/*" 
-                                        onChange={(event) => {
-                                            const targetImage = event.target.files[0];
-                                            const reader = new FileReader();
-                                            reader.onload = () => {
-                                                setImage({
-                                                    src: reader.result,
-                                                    blob: targetImage
-                                                });
-                                            };
-                                            reader.readAsDataURL(targetImage);
-                                        }} 
+                                </div>
+                                <div className="flex-col-input description-input">
+                                    <label className="class-form-label">
+                                        Description
+                                    </label>
+                                    <textarea
+                                        className="class-form-textarea"
+                                        name="instructions"
+                                        placeholder="Enter Description Here"
+                                        rows="6"
+                                        value={values.instructions}
+                                        onChange={handleChange}
+                                        onBlur={handleBlur}
+                                        errors={errors}
+                                        touched={touched}
                                     />
                                     
                                 </div>
                             </div>
-                            <div className="flex-col-input description-input">
-                                <label className="class-form-label">
-                                    Description
-                                </label>
-                                <textarea
-                                    className="class-form-textarea"
-                                    name="instructions"
-                                    placeholder="Enter Description Here"
-                                    rows="6"
-                                    value={values.instructions}
-                                    onChange={handleChange}
-                                    onBlur={handleBlur}
-                                    errors={errors}
-                                    touched={touched}
-                                />
-                            </div>
+                            {errors["instructions"] && touched["instructions"] && (
+                                <div className="invalid-message">{errors["instructions"]}</div>
+                            )}
                         </div>
                         <div className="input-row">
                             <div className="error-wrapper">

--- a/frontend/src/components/AdminClassForm/index.js
+++ b/frontend/src/components/AdminClassForm/index.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
-import { Formik, FieldArray } from "formik";
+import { Formik, FieldArray, useFormikContext } from "formik";
 import * as Yup from "yup";
 import { CgSelect } from "react-icons/cg";
 import upload_light from "../../assets/upload-light.png";
@@ -116,6 +116,16 @@ const ClassSchema = Yup.object().shape({
     image: Yup.string().optional(),
 });
 
+function AutoResetForm({ initialValues }) {
+    const { resetForm } = useFormikContext();
+
+    useEffect(() => {
+        resetForm({ values: initialValues });
+    }, [initialValues, resetForm]);
+
+    return null; // No UI needed, just handling reset
+};
+
 function AdminClassForm({ setUpdates }) {
 
     const [loading, setLoading] = useState(true);
@@ -220,7 +230,6 @@ function AdminClassForm({ setUpdates }) {
         fetchData();
     }, []);
 
-
     function buildVolunteers(assignedVolunteerIds) {
         return volunteers.filter((volunteer) => !assignedVolunteerIds.includes(volunteer.value.volunteer_id));
     }
@@ -317,6 +326,7 @@ function AdminClassForm({ setUpdates }) {
     return (
         <div className="class-form">
             <Formik
+                enableReinitialize={true}
                 initialValues={classData}
                 validationSchema={ClassSchema}
                 onSubmit={(values, { setSubmitting }) => {
@@ -338,6 +348,7 @@ function AdminClassForm({ setUpdates }) {
                     isSubmitting
                 }) => (
                 <form onSubmit={handleSubmit} className="form-body">
+                    <AutoResetForm initialValues={classData} />
                     <div className="form-block">
                         <h2 className="section-title">General</h2>
                         

--- a/frontend/src/components/AdminDetailsPanel/index.js
+++ b/frontend/src/components/AdminDetailsPanel/index.js
@@ -34,7 +34,7 @@ function AdminDetailsPanel({
                             <h2 className="delete-popup-title">Delete Class</h2>
                             <p className="delete-popup-prompt">Delete this class permanently?</p>
                             <div className="delete-popup-buttons">
-                                <button type="button" className="cancel-button" onClick={() => setShowPopup(false)}>
+                                <button type="button" className="cancel-delete-button" onClick={() => setShowPopup(false)}>
                                     Cancel
                                 </button>
                                 <button

--- a/frontend/src/pages/Classes/index.css
+++ b/frontend/src/pages/Classes/index.css
@@ -77,7 +77,7 @@
 /* ----- */
 
 .add-class-button {
-  width: stretch;
+  width: 100%;
   background: #fff;
   border: 2px dashed #D9D9D9;
   border-radius: 8px;
@@ -169,28 +169,30 @@
 
 .delete-popup-buttons {
   display: flex;
-  width: stretch;
+  width: 100%;
   gap: 12px;
 }
 
-.cancel-button {
-  width: stretch;
+.cancel-delete-button {
+  flex: 1;
+  align-self: stretch;
   padding: 12px 16px;
   border-radius: 8px;
   border: 1px solid #bcbcbc;
   background: #FFF;
 }
 
-.cancel-button:hover {
+.cancel-delete-button:hover {
   cursor: pointer;
   background: #fafafa;
 }
 
 .confirm-delete-button {
-  width: stretch;
+  flex: 1;
+  align-self: stretch;
   border: none;
   color: #fff;
-  text-wrap: nowrap;
+  white-space: nowrap;
   border-radius: 8px;
   padding: 12px 16px;
   background-color: #952018;


### PR DESCRIPTION
Added character limits to admin class form and made some styling improvements.

## Database
- changed `instructions` from `VARCHAR(150)` to `VARCHAR(3000)`

## Frontend
- added re-initialization to the form using formik context, so when in the edit class page, users can navigate to a different class in the details panel, click 'edit class' and have the form populate itself with the new class's values 
- added max chars to formik schema, for example:
```js
instructions: Yup.string()
        .max(3000, 'Description cannot exceed 3000 characters.')
        .optional(),
```

Not sure if this is necessary, but I also made some changes to allow the page to work on mobile devices: 
![screen-sizing](https://github.com/user-attachments/assets/5e12020f-6298-488a-a346-876e82b22ed5)

