### PR TITLE
Add withdraw absence request button for volunteers

### DIFF
--- a/frontend/src/components/ShiftCard/index.js
+++ b/frontend/src/components/ShiftCard/index.js
@@ -7,16 +7,15 @@ function ShiftCard({ shift, shiftType, onShiftSelect, buttonConfig }) {
     onShiftSelect(shift);
   };
 
-  const { lineColor, label, icon, disabled, buttonClass, onClick } =
-    buttonConfig?.[shiftType] ||
-      buttonConfig?.[SHIFT_TYPES.DEFAULT] || 
-      buttonConfig?.[ADMIN_SHIFT_TYPES.ADMIN_COVERED] || {
-        lineColor: "var(--grey)",
-        label: "View Details",
-        icon: null,
-        disabled: false,
-        onClick: () => {},
-      };
+  const {
+    lineColor = "var(--grey)",
+    label = "View Details",
+    icon = null,
+    disabled = false,
+    buttonClass = "",
+    onClick = () => {},
+  } = buttonConfig || {};
+  
 
   const parseShiftDuration = (duration) => {
     const hours = Math.round((duration / 60) * 10) / 10;

--- a/frontend/src/components/VolunteerDetailsPanel/index.css
+++ b/frontend/src/components/VolunteerDetailsPanel/index.css
@@ -225,3 +225,15 @@
      filter: brightness(0.8);
      cursor: pointer;
 }
+
+.dynamic-button.withdraw-request {
+     color: var(--red);
+     background: #fff;
+     border: 1px solid var(--red);
+   }
+   
+   .dynamic-button.withdraw-request:hover {
+     color: var(--red-hover);
+     border-color: var(--red-hover);
+     background: #fff;
+   }   

--- a/frontend/src/pages/Schedule/index.js
+++ b/frontend/src/pages/Schedule/index.js
@@ -251,10 +251,16 @@ function Schedule() {
 
         const buttons = [];
         const buttonConfig = getButtonConfig(shift, handleShiftUpdate, isAdmin ? null : user?.volunteer.volunteer_id);
-        const primaryButton = buttonConfig[shift.shift_type]
+        const primaryButtons = buttonConfig[shift.shift_type]
 
-        if (primaryButton.label && !pastShift) {
-            buttons.push(primaryButton);
+        if (Array.isArray(primaryButtons)) {
+            primaryButtons.forEach((btn) => {
+                if (btn.label && !pastShift) {
+                    buttons.push(btn);
+                }
+            });
+        } else if (primaryButtons?.label && !pastShift) {
+            buttons.push(primaryButtons);
         }
 
         if (isAdmin && !pastShift) {
@@ -349,16 +355,22 @@ function Schedule() {
 
                                             {/* Shift List for this date */}
                                             <div className="shift-list">
-                                                {groupedShifts[date].map((shift) => (
+                                            {groupedShifts[date].map((shift) => {
+                                                const config = getButtonConfig(shift, handleShiftUpdate, isAdmin ? null : user?.volunteer?.volunteer_id);
+                                                const buttonConfig = Array.isArray(config[shift.shift_type])
+                                                    ? config[shift.shift_type][0]
+                                                    : config[shift.shift_type];
+
+                                                return (
                                                     <ShiftCard
                                                         key={shift.shift_id}
                                                         shift={shift}
                                                         shiftType={shift.shift_type}
                                                         onShiftSelect={handleShiftSelection}
-                                                        // getButtonConfig sets volunteerID to null for Admin accounts
-                                                        buttonConfig={getButtonConfig(shift, handleShiftUpdate, isAdmin ? null : user?.volunteer.volunteer_id)}
+                                                        buttonConfig={buttonConfig}
                                                     />
-                                                ))}
+                                                );
+                                            })}
                                             </div>
                                         </div>
                                     ))

--- a/frontend/src/utils/buttonConfig.js
+++ b/frontend/src/utils/buttonConfig.js
@@ -162,13 +162,35 @@ export const getButtonConfig = (
       onClick: () =>
         handleCoverShiftClick(shift, handleShiftUpdate, volunteerID),
     },
-    [SHIFT_TYPES.MY_COVERAGE_REQUESTS]: {
-      lineColor: "var(--yellow)",
-      label: "Request Pending",
-      icon: null,
-      disabled: true,
-      onClick: () => {}, // No action for this state
-    },
+    [SHIFT_TYPES.MY_COVERAGE_REQUESTS]: [
+      {
+        lineColor: "var(--yellow)",
+        label: "Request Pending",
+        icon: null,
+        disabled: true,
+        onClick: () => {}, // No action for this state
+      },
+      {
+        label: "Withdraw Request",
+        icon: null,
+        disabled: false,
+        buttonClass: "withdraw-request",
+        onClick: () => {
+          withdrawAbsenceRequest(shift.request_id)
+            .then(() => {
+              handleShiftUpdate({
+                ...shift,
+                shift_type: SHIFT_TYPES.MY_SHIFTS,
+                coverage_status: null,
+                request_id: null,
+              });
+            })
+            .catch((error) => {
+              console.error("Error withdrawing absence request:", error);
+            });
+        },
+      },
+    ],
     [SHIFT_TYPES.DEFAULT]: {
       lineColor: "var(--grey)",
       label: "View Details",


### PR DESCRIPTION
This PR introduces a new "Withdraw Request" button for volunteers who have submitted an absence request. This allows them to view their pending request and (eventually) cancel it directly from the Details Panel.

✅ What’s Included
Added a new "Withdraw Request" button to MY_COVERAGE_REQUESTS in buttonConfig.js

Updated getButtonConfig() to return multiple buttons for MY_COVERAGE_REQUESTS:

🔹 “Request Pending” (non-clickable, gray)

🔹 “Withdraw Request” (clickable, red-bordered)

Adjusted Schedule page logic to support button arrays in generateButtonsForDetailsPanel()

Ensured only the first button (e.g., “Request Pending”) is shown in the ShiftCard

Updated ShiftCard to properly use a resolved button config (not buttonConfig[shiftType])

Applied CSS styling for .withdraw-request button

Red text, red border, white background

⚠️ Not Yet Completed
The "Withdraw Request" button currently calls the correct handler, but:

shift.request_id is sometimes undefined

❌ Backend call fails with DELETE /absence/undefined/withdraw

Cancel functionality needs to be fully wired up and tested once request IDs are properly attached to shift data

🧪 What to Test
Clicking on a shift with an absence request should:

Show both buttons in the Details Panel

NOT show the Withdraw button on the main Schedule view

Confirm styling of the Withdraw button matches design expectations