### PR TITLE
Add the list coverage method

### DIFF
--- a/src/models/api/coverage.ts
+++ b/src/models/api/coverage.ts
@@ -1,6 +1,7 @@
 import { StringEnum } from "@/lib/base-enum";
 import { createStringEnum } from "@/utils/typeUtils";
 import { z } from "zod";
+import { ListRequest } from "./common";
 
 export const CoverageStatusEnum = z.enum([
   "open",
@@ -17,14 +18,17 @@ export const CoverageRequestCategoryEnum = z.enum([
   "transportation",
   "other",
 ] as const);
-export type CoverageRequestCategory = z.infer<typeof CoverageRequestCategoryEnum>;
-export const CoverageRequestCategory = StringEnum.createFromType<CoverageRequestCategory>({
-  emergency: "Emergency",
-  health: "Health",
-  conflict: "Scheduling Conflict",
-  transportation: "Transportation",
-  other: "Other",
-});
+export type CoverageRequestCategory = z.infer<
+  typeof CoverageRequestCategoryEnum
+>;
+export const CoverageRequestCategory =
+  StringEnum.createFromType<CoverageRequestCategory>({
+    emergency: "Emergency",
+    health: "Health",
+    conflict: "Scheduling Conflict",
+    transportation: "Transportation",
+    other: "Other",
+  });
 
 export const CreateCoverageRequest = z.object({
   shiftId: z.uuid(),
@@ -37,3 +41,10 @@ export type CreateCoverageRequest = z.infer<typeof CreateCoverageRequest>;
 export const CoverageRequestIdInput = z.object({
   coverageRequestId: z.uuid(),
 });
+
+export const ListCoverageRequestsInput = ListRequest.extend({
+  status: CoverageStatusEnum.optional(),
+});
+export type ListCoverageRequestsInput = z.infer<
+  typeof ListCoverageRequestsInput
+>;

--- a/src/models/coverage.ts
+++ b/src/models/coverage.ts
@@ -26,7 +26,7 @@ export function buildCoverageRequest(
     details: coverageDB.details,
     comments: coverageDB.comments ?? undefined,
     requestingVolunteer: requestingVolunteer,
-    coveringVolunteer: coveringVolunteer
+    coveringVolunteer: coveringVolunteer,
   } as const;
 }
 
@@ -39,7 +39,9 @@ export function getSingleCoverageRequest(r: CoverageRequest) {
     details: r.details,
     comments: r.comments,
     requestingVolunteer: getEmbeddedVolunteer(r.requestingVolunteer),
-    coveringVolunteer: r.coveringVolunteer ? getEmbeddedVolunteer(r.coveringVolunteer) : undefined
+    coveringVolunteer: r.coveringVolunteer
+      ? getEmbeddedVolunteer(r.coveringVolunteer)
+      : undefined,
   } as const;
 }
 
@@ -49,9 +51,60 @@ export function getEmbeddedCoverageRequest(r: CoverageRequest) {
     shiftId: r.shiftId,
     status: r.status,
     requestingVolunteer: getEmbeddedVolunteer(r.requestingVolunteer),
-    coveringVolunteer: r.coveringVolunteer ? getEmbeddedVolunteer(r.coveringVolunteer) : undefined
+    coveringVolunteer: r.coveringVolunteer
+      ? getEmbeddedVolunteer(r.coveringVolunteer)
+      : undefined,
   } as const;
 }
 
 export type SingleCoverageRequest = ReturnType<typeof getSingleCoverageRequest>;
-export type EmbeddedCoverageRequest = ReturnType<typeof getEmbeddedCoverageRequest>;
+export type EmbeddedCoverageRequest = ReturnType<
+  typeof getEmbeddedCoverageRequest
+>;
+
+// Shift context for coverage list display
+export type CoverageRequestShiftContext = {
+  id: string;
+  date: string;
+  startAt: Date;
+  endAt: Date;
+  className: string;
+  classId: string;
+};
+
+// Base list item (visible to all users who can see the request)
+export function getListCoverageRequestBase(
+  r: CoverageRequest,
+  shiftContext: CoverageRequestShiftContext,
+) {
+  return {
+    id: r.id,
+    shiftId: r.shiftId,
+    status: r.status,
+    shift: shiftContext,
+    requestingVolunteer: getEmbeddedVolunteer(r.requestingVolunteer),
+    coveringVolunteer: r.coveringVolunteer
+      ? getEmbeddedVolunteer(r.coveringVolunteer)
+      : undefined,
+  } as const;
+}
+
+// Admin list item (includes reason fields: category, details, comments)
+export function getListCoverageRequestWithReason(
+  r: CoverageRequest,
+  shiftContext: CoverageRequestShiftContext,
+) {
+  return {
+    ...getListCoverageRequestBase(r, shiftContext),
+    category: r.category,
+    details: r.details,
+    comments: r.comments,
+  } as const;
+}
+
+export type ListCoverageRequestBase = ReturnType<
+  typeof getListCoverageRequestBase
+>;
+export type ListCoverageRequestWithReason = ReturnType<
+  typeof getListCoverageRequestWithReason
+>;

--- a/src/server/api/routers/coverage-router.ts
+++ b/src/server/api/routers/coverage-router.ts
@@ -1,11 +1,26 @@
 import {
   CoverageRequestIdInput,
   CreateCoverageRequest,
+  ListCoverageRequestsInput,
 } from "@/models/api/coverage";
+import { Role } from "@/models/interfaces";
 import { authorizedProcedure } from "@/server/api/procedures";
 import { createTRPCRouter } from "@/server/api/trpc";
 
 export const coverageRouter = createTRPCRouter({
+  list: authorizedProcedure({
+    permission: { coverage: ["view"] },
+  })
+    .input(ListCoverageRequestsInput)
+    .query(async ({ input, ctx }) => {
+      const currentUser = ctx.session.user;
+
+      return await ctx.coverageService.listCoverageRequests(
+        input,
+        currentUser.id,
+        currentUser.role as Role,
+      );
+    }),
   requestCoverage: authorizedProcedure({
     permission: { coverage: ["request"] },
   })
@@ -13,7 +28,10 @@ export const coverageRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       const currentUser = ctx.session.user;
 
-      return await ctx.coverageService.createCoverageRequest(currentUser.id, input);
+      return await ctx.coverageService.createCoverageRequest(
+        currentUser.id,
+        input,
+      );
     }),
   cancelCoverageRequest: authorizedProcedure({
     permission: { coverage: ["request"] },
@@ -22,7 +40,10 @@ export const coverageRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       const currentUser = ctx.session.user;
 
-      await ctx.coverageService.cancelCoverageRequest(currentUser.id, input.coverageRequestId);
+      await ctx.coverageService.cancelCoverageRequest(
+        currentUser.id,
+        input.coverageRequestId,
+      );
     }),
   fillCoverageRequest: authorizedProcedure({
     permission: { coverage: ["fill"] },
@@ -31,7 +52,10 @@ export const coverageRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       const currentUser = ctx.session.user;
 
-      await ctx.coverageService.fulfillCoverageRequest(currentUser.id, input.coverageRequestId);
+      await ctx.coverageService.fulfillCoverageRequest(
+        currentUser.id,
+        input.coverageRequestId,
+      );
     }),
   unassignCoverage: authorizedProcedure({
     permission: { coverage: ["fill"] },
@@ -40,6 +64,9 @@ export const coverageRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       const currentUser = ctx.session.user;
 
-      await ctx.coverageService.unassignCoverage(currentUser.id, input.coverageRequestId);
-    })
+      await ctx.coverageService.unassignCoverage(
+        currentUser.id,
+        input.coverageRequestId,
+      );
+    }),
 });

--- a/src/server/services/entity/coverageService.ts
+++ b/src/server/services/entity/coverageService.ts
@@ -1,215 +1,399 @@
-import { CoverageStatus, type CreateCoverageRequest } from "@/models/api/coverage";
-import { buildCoverageRequest, type CoverageRequest } from "@/models/coverage";
+import {
+  CoverageStatus,
+  type CreateCoverageRequest,
+  type ListCoverageRequestsInput,
+} from "@/models/api/coverage";
+import {
+  buildCoverageRequest,
+  getListCoverageRequestBase,
+  getListCoverageRequestWithReason,
+  type CoverageRequest,
+  type CoverageRequestShiftContext,
+  type ListCoverageRequestBase,
+  type ListCoverageRequestWithReason,
+} from "@/models/coverage";
+import { Role } from "@/models/interfaces";
+import type { ListResponse } from "@/models/list-response";
 import type { Drizzle } from "@/server/db";
-import { coverageRequest, type CoverageRequestDB } from "@/server/db/schema";
+import { course } from "@/server/db/schema/course";
+import {
+  coverageRequest,
+  shift,
+  type CoverageRequestDB,
+} from "@/server/db/schema";
 import { NeuronError, NeuronErrorCodes } from "@/server/errors/neuron-error";
 import { toMap, uniqueDefined } from "@/utils/arrayUtils";
-import { eq, inArray, and } from "drizzle-orm/sql";
+import { getPagination } from "@/utils/searchUtils";
+import { and, desc, eq, inArray, or, sql, type SQL } from "drizzle-orm";
 import type { VolunteerService } from "./volunteerService";
-import { shift } from "@/server/db/schema";
 import type { ShiftService } from "./shiftService";
 
 export class CoverageService {
-    private readonly db: Drizzle;
-    private readonly volunteerService: VolunteerService;
-    private readonly shiftService: ShiftService;
-  
-    constructor(
-        db: Drizzle, 
-        volunteerService: VolunteerService,
-        shiftService: ShiftService,
-    ) {
-        this.db = db;
-        this.volunteerService = volunteerService;
-        this.shiftService = shiftService;
+  private readonly db: Drizzle;
+  private readonly volunteerService: VolunteerService;
+  private readonly shiftService: ShiftService;
+
+  constructor(
+    db: Drizzle,
+    volunteerService: VolunteerService,
+    shiftService: ShiftService,
+  ) {
+    this.db = db;
+    this.volunteerService = volunteerService;
+    this.shiftService = shiftService;
+  }
+
+  async getCoverageRequestsForShift(
+    shiftId: string,
+  ): Promise<CoverageRequest[]> {
+    const coverageRequestDBs = await this.db
+      .select()
+      .from(coverageRequest)
+      .where(eq(coverageRequest.shiftId, shiftId));
+
+    return this.formatCoverageRequests(coverageRequestDBs);
+  }
+
+  async listCoverageRequests(
+    input: ListCoverageRequestsInput,
+    viewerUserId: string,
+    viewerRole: Role,
+  ): Promise<
+    ListResponse<ListCoverageRequestBase | ListCoverageRequestWithReason>
+  > {
+    const { perPage, offset, status } = getPagination(input);
+    const isAdmin = viewerRole === Role.admin;
+
+    // Build WHERE conditions
+    const whereConditions: SQL<unknown>[] = [];
+
+    // Optional status filter
+    if (status) {
+      whereConditions.push(eq(coverageRequest.status, status));
     }
 
-    async getCoverageRequestsForShift(shiftId: string): Promise<CoverageRequest[]>  {
-        const coverageRequestDBs = await this.db.select()
-            .from(coverageRequest)
-            .where(eq(coverageRequest.shiftId, shiftId));
-
-        return this.formatCoverageRequests(coverageRequestDBs);
+    // Role-based visibility filter (volunteers only see open or their own requests)
+    if (!isAdmin) {
+      whereConditions.push(
+        or(
+          eq(coverageRequest.status, CoverageStatus.open),
+          eq(coverageRequest.requestingVolunteerUserId, viewerUserId),
+          eq(coverageRequest.coveredByVolunteerUserId, viewerUserId),
+        )!,
+      );
     }
 
-    async getCoverageRequestById(id: string): Promise<CoverageRequest>  {
-        return this.getCoverageRequestByIds([id]).then(req => req[0]!);
+    // Query with pagination and total count
+    const rows = await this.db
+      .select({
+        totalRecords: sql<number>`count(*) over()`,
+        coverageRequest: coverageRequest,
+        shift: {
+          id: shift.id,
+          date: shift.date,
+          startAt: shift.startAt,
+          endAt: shift.endAt,
+        },
+        course: {
+          id: course.id,
+          name: course.name,
+        },
+      })
+      .from(coverageRequest)
+      .innerJoin(shift, eq(coverageRequest.shiftId, shift.id))
+      .innerJoin(course, eq(shift.courseId, course.id))
+      .where(whereConditions.length > 0 ? and(...whereConditions) : undefined)
+      .orderBy(desc(shift.startAt), desc(coverageRequest.id))
+      .limit(perPage)
+      .offset(offset);
+
+    if (rows.length === 0) {
+      return { data: [], total: 0, nextCursor: null };
     }
 
-    async getCoverageRequestByIds(ids: string[]): Promise<CoverageRequest[]>  {
-        const coverageRequestDBs = await this.db.select()
-            .from(coverageRequest)
-            .where(inArray(coverageRequest.id, ids));
+    // Extract volunteer IDs for batch loading
+    const volunteerIds = uniqueDefined(
+      rows
+        .flatMap((row) => [
+          row.coverageRequest.requestingVolunteerUserId,
+          row.coverageRequest.coveredByVolunteerUserId,
+        ])
+        .filter((id): id is string => id !== null),
+    );
 
-        if (coverageRequestDBs.length !== ids.length) {
-            throw new NeuronError("Unable to find coverage request", NeuronErrorCodes.BAD_REQUEST);
-        }
+    // Batch load volunteers
+    const volunteers = toMap(
+      await this.volunteerService.getVolunteers(volunteerIds),
+    );
 
-        return this.formatCoverageRequests(coverageRequestDBs);
+    // Calculate pagination
+    const total = rows[0]?.totalRecords ?? 0;
+    const loadedSoFar = offset + rows.length;
+    const nextCursor = loadedSoFar < total ? loadedSoFar : null;
+
+    // Map to response type based on role
+    const data = rows.map((row) => {
+      const requestingVolunteer = volunteers.get(
+        row.coverageRequest.requestingVolunteerUserId,
+      )!;
+      const coveringVolunteer = row.coverageRequest.coveredByVolunteerUserId
+        ? volunteers.get(row.coverageRequest.coveredByVolunteerUserId)
+        : undefined;
+
+      const coverageModel = buildCoverageRequest(
+        row.coverageRequest,
+        requestingVolunteer,
+        coveringVolunteer,
+      );
+
+      const shiftContext: CoverageRequestShiftContext = {
+        id: row.shift.id,
+        date: row.shift.date,
+        startAt: row.shift.startAt,
+        endAt: row.shift.endAt,
+        className: row.course.name,
+        classId: row.course.id,
+      };
+
+      // Return admin view with reason fields, or base view for volunteers
+      if (isAdmin) {
+        return getListCoverageRequestWithReason(coverageModel, shiftContext);
+      }
+      return getListCoverageRequestBase(coverageModel, shiftContext);
+    });
+
+    return { data, total, nextCursor };
+  }
+
+  async getCoverageRequestById(id: string): Promise<CoverageRequest> {
+    return this.getCoverageRequestByIds([id]).then((req) => req[0]!);
+  }
+
+  async getCoverageRequestByIds(ids: string[]): Promise<CoverageRequest[]> {
+    const coverageRequestDBs = await this.db
+      .select()
+      .from(coverageRequest)
+      .where(inArray(coverageRequest.id, ids));
+
+    if (coverageRequestDBs.length !== ids.length) {
+      throw new NeuronError(
+        "Unable to find coverage request",
+        NeuronErrorCodes.BAD_REQUEST,
+      );
     }
 
-    async createCoverageRequest(requestingVolunteerUserId: string, requestData: CreateCoverageRequest): Promise<string> {
-        await this.shiftService.assertValidShift(requestingVolunteerUserId, requestData.shiftId);
+    return this.formatCoverageRequests(coverageRequestDBs);
+  }
 
-        const [created] = await this.db.insert(coverageRequest).values({
-                shiftId: requestData.shiftId,
-                category: requestData.category,
-                details: requestData.details,
-                comments: requestData.comments,
-                requestingVolunteerUserId: requestingVolunteerUserId,
-            })
-            .returning({ id: coverageRequest.id });
+  async createCoverageRequest(
+    requestingVolunteerUserId: string,
+    requestData: CreateCoverageRequest,
+  ): Promise<string> {
+    await this.shiftService.assertValidShift(
+      requestingVolunteerUserId,
+      requestData.shiftId,
+    );
 
-        return created!.id;
+    const [created] = await this.db
+      .insert(coverageRequest)
+      .values({
+        shiftId: requestData.shiftId,
+        category: requestData.category,
+        details: requestData.details,
+        comments: requestData.comments,
+        requestingVolunteerUserId: requestingVolunteerUserId,
+      })
+      .returning({ id: coverageRequest.id });
+
+    return created!.id;
+  }
+
+  async cancelCoverageRequest(
+    requestingVolunteerUserId: string,
+    coverageRequestId: string,
+  ): Promise<void> {
+    const [request] = await this.db
+      .select({
+        status: coverageRequest.status,
+        shiftStartAt: shift.startAt,
+      })
+      .from(coverageRequest)
+      .innerJoin(shift, eq(coverageRequest.shiftId, shift.id))
+      .where(
+        and(
+          eq(coverageRequest.id, coverageRequestId),
+          eq(
+            coverageRequest.requestingVolunteerUserId,
+            requestingVolunteerUserId,
+          ),
+        ),
+      );
+
+    if (!request) {
+      throw new NeuronError(
+        `Could not find coverage request with id ${coverageRequestId} requested by volunteer with id ${requestingVolunteerUserId}.`,
+        NeuronErrorCodes.NOT_FOUND,
+      );
     }
 
-    async cancelCoverageRequest(requestingVolunteerUserId: string, coverageRequestId: string): Promise<void> {
-        const [request] = await this.db
-            .select({
-                status: coverageRequest.status,
-                shiftStartAt: shift.startAt,
-            })
-            .from(coverageRequest)
-            .innerJoin(shift, eq(coverageRequest.shiftId, shift.id))
-            .where(
-                and(
-                    eq(coverageRequest.id, coverageRequestId),
-                    eq(coverageRequest.requestingVolunteerUserId, requestingVolunteerUserId),
-                )
-            );
-
-        if (!request) {
-            throw new NeuronError(
-                `Could not find coverage request with id ${coverageRequestId} requested by volunteer with id ${requestingVolunteerUserId}.`, 
-                NeuronErrorCodes.NOT_FOUND,
-            );
-        }
-
-        if (request.status != CoverageStatus.open) {
-            throw new NeuronError(
-                "Coverage request is not open.", 
-                NeuronErrorCodes.BAD_REQUEST,
-            );
-        }
-
-        if (request.shiftStartAt <= new Date()) {
-            throw new NeuronError(
-                "Can not cancel a coverage request for a past shift.", 
-                NeuronErrorCodes.BAD_REQUEST,
-            );
-        }
-
-        const affected = await this.db.update(coverageRequest).set({
-            status: CoverageStatus.withdrawn,
-        })
-        .where(eq(coverageRequest.id, coverageRequestId))
-        .returning();
-
-        if (affected.length < 1) {
-            throw new NeuronError("Failed to cancel coverage request", NeuronErrorCodes.BAD_REQUEST);
-        }
+    if (request.status != CoverageStatus.open) {
+      throw new NeuronError(
+        "Coverage request is not open.",
+        NeuronErrorCodes.BAD_REQUEST,
+      );
     }
 
-    async fulfillCoverageRequest(coveredByVolunteerUserId: string, coverageRequestId: string): Promise<void> {
-        const [request] = await this.db
-            .select({
-                status: coverageRequest.status,
-                shiftStartAt: shift.startAt,
-            })
-            .from(coverageRequest)
-            .innerJoin(shift, eq(coverageRequest.shiftId, shift.id))
-            .where(eq(coverageRequest.id, coverageRequestId));
-
-        if (!request) {
-            throw new NeuronError(
-                `Could not find coverage request with id ${coverageRequestId}.`, 
-                NeuronErrorCodes.NOT_FOUND,
-            );
-        }
-
-        if (request.status != CoverageStatus.open) {
-            throw new NeuronError(
-                "Coverage request is not open.", 
-                NeuronErrorCodes.BAD_REQUEST,
-            );
-        }
-
-        if (request.shiftStartAt <= new Date()) {
-            throw new NeuronError(
-                "Can not fulfill a coverage request for a past shift.", 
-                NeuronErrorCodes.BAD_REQUEST,
-            );
-        }
-    
-        const affected = await this.db.update(coverageRequest).set({
-            status: CoverageStatus.resolved,
-            coveredByVolunteerUserId: coveredByVolunteerUserId
-        }).where(
-            eq(coverageRequest.id, coverageRequestId)
-        )
-        .returning();
-
-        if (affected.length < 1) {
-            throw new NeuronError("Failed to fill coverage request", NeuronErrorCodes.BAD_REQUEST);
-        }
+    if (request.shiftStartAt <= new Date()) {
+      throw new NeuronError(
+        "Can not cancel a coverage request for a past shift.",
+        NeuronErrorCodes.BAD_REQUEST,
+      );
     }
 
-    async unassignCoverage(coveredByVolunteerUserId: string, coverageRequestId: string): Promise<void> {
-        const [request] = await this.db
-            .select({
-                status: coverageRequest.status,
-                shiftStartAt: shift.startAt,
-            })
-            .from(coverageRequest)
-            .innerJoin(shift, eq(coverageRequest.shiftId, shift.id))
-            .where(
-                and(
-                    eq(coverageRequest.id, coverageRequestId),
-                    eq(coverageRequest.coveredByVolunteerUserId, coveredByVolunteerUserId),
-                )
-            );
+    const affected = await this.db
+      .update(coverageRequest)
+      .set({
+        status: CoverageStatus.withdrawn,
+      })
+      .where(eq(coverageRequest.id, coverageRequestId))
+      .returning();
 
-        if (!request) {
-            throw new NeuronError(
-                `Could not find coverage request with id ${coverageRequestId} covered by volunteer with id ${coveredByVolunteerUserId}.`, 
-                NeuronErrorCodes.NOT_FOUND,
-            );
-        }
+    if (affected.length < 1) {
+      throw new NeuronError(
+        "Failed to cancel coverage request",
+        NeuronErrorCodes.BAD_REQUEST,
+      );
+    }
+  }
 
-        if (request.shiftStartAt <= new Date()) {
-            throw new NeuronError(
-                "Can not unassign coverage to a coverage request for a past shift.", 
-                NeuronErrorCodes.BAD_REQUEST,
-            );
-        }
+  async fulfillCoverageRequest(
+    coveredByVolunteerUserId: string,
+    coverageRequestId: string,
+  ): Promise<void> {
+    const [request] = await this.db
+      .select({
+        status: coverageRequest.status,
+        shiftStartAt: shift.startAt,
+      })
+      .from(coverageRequest)
+      .innerJoin(shift, eq(coverageRequest.shiftId, shift.id))
+      .where(eq(coverageRequest.id, coverageRequestId));
 
-        const affected = await this.db.update(coverageRequest).set({
-            status: CoverageStatus.open,
-            requestingVolunteerUserId: coveredByVolunteerUserId,
-            coveredByVolunteerUserId: null,
-        }).where(
-            eq(coverageRequest.id, coverageRequestId)
-        )
-        .returning();
-
-        if (affected.length < 1) {
-            throw new NeuronError("Failed to unassign coverage.", NeuronErrorCodes.BAD_REQUEST);
-        }
+    if (!request) {
+      throw new NeuronError(
+        `Could not find coverage request with id ${coverageRequestId}.`,
+        NeuronErrorCodes.NOT_FOUND,
+      );
     }
 
-    private async formatCoverageRequests(requestDBs: CoverageRequestDB[]): Promise<CoverageRequest[]> {
-        // Dedupe and get volunteers
-        const volunteerIds = uniqueDefined(requestDBs.flatMap((request) =>
-            [request.coveredByVolunteerUserId, request.requestingVolunteerUserId]
-        ).filter(r => r !== null));
-        const volunteers = toMap(await this.volunteerService.getVolunteers(volunteerIds));
-    
-        return requestDBs.map((req) =>
-            buildCoverageRequest(
-                req,
-                volunteers.get(req.requestingVolunteerUserId)!,
-                req.coveredByVolunteerUserId ? volunteers.get(req.coveredByVolunteerUserId)! : undefined
-            ),
-        );
+    if (request.status != CoverageStatus.open) {
+      throw new NeuronError(
+        "Coverage request is not open.",
+        NeuronErrorCodes.BAD_REQUEST,
+      );
     }
+
+    if (request.shiftStartAt <= new Date()) {
+      throw new NeuronError(
+        "Can not fulfill a coverage request for a past shift.",
+        NeuronErrorCodes.BAD_REQUEST,
+      );
+    }
+
+    const affected = await this.db
+      .update(coverageRequest)
+      .set({
+        status: CoverageStatus.resolved,
+        coveredByVolunteerUserId: coveredByVolunteerUserId,
+      })
+      .where(eq(coverageRequest.id, coverageRequestId))
+      .returning();
+
+    if (affected.length < 1) {
+      throw new NeuronError(
+        "Failed to fill coverage request",
+        NeuronErrorCodes.BAD_REQUEST,
+      );
+    }
+  }
+
+  async unassignCoverage(
+    coveredByVolunteerUserId: string,
+    coverageRequestId: string,
+  ): Promise<void> {
+    const [request] = await this.db
+      .select({
+        status: coverageRequest.status,
+        shiftStartAt: shift.startAt,
+      })
+      .from(coverageRequest)
+      .innerJoin(shift, eq(coverageRequest.shiftId, shift.id))
+      .where(
+        and(
+          eq(coverageRequest.id, coverageRequestId),
+          eq(
+            coverageRequest.coveredByVolunteerUserId,
+            coveredByVolunteerUserId,
+          ),
+        ),
+      );
+
+    if (!request) {
+      throw new NeuronError(
+        `Could not find coverage request with id ${coverageRequestId} covered by volunteer with id ${coveredByVolunteerUserId}.`,
+        NeuronErrorCodes.NOT_FOUND,
+      );
+    }
+
+    if (request.shiftStartAt <= new Date()) {
+      throw new NeuronError(
+        "Can not unassign coverage to a coverage request for a past shift.",
+        NeuronErrorCodes.BAD_REQUEST,
+      );
+    }
+
+    const affected = await this.db
+      .update(coverageRequest)
+      .set({
+        status: CoverageStatus.open,
+        requestingVolunteerUserId: coveredByVolunteerUserId,
+        coveredByVolunteerUserId: null,
+      })
+      .where(eq(coverageRequest.id, coverageRequestId))
+      .returning();
+
+    if (affected.length < 1) {
+      throw new NeuronError(
+        "Failed to unassign coverage.",
+        NeuronErrorCodes.BAD_REQUEST,
+      );
+    }
+  }
+
+  private async formatCoverageRequests(
+    requestDBs: CoverageRequestDB[],
+  ): Promise<CoverageRequest[]> {
+    // Dedupe and get volunteers
+    const volunteerIds = uniqueDefined(
+      requestDBs
+        .flatMap((request) => [
+          request.coveredByVolunteerUserId,
+          request.requestingVolunteerUserId,
+        ])
+        .filter((r) => r !== null),
+    );
+    const volunteers = toMap(
+      await this.volunteerService.getVolunteers(volunteerIds),
+    );
+
+    return requestDBs.map((req) =>
+      buildCoverageRequest(
+        req,
+        volunteers.get(req.requestingVolunteerUserId)!,
+        req.coveredByVolunteerUserId
+          ? volunteers.get(req.coveredByVolunteerUserId)!
+          : undefined,
+      ),
+    );
+  }
 }


### PR DESCRIPTION
**PR Summary**
- Added a paginated coverage request list flow with role-based visibility and reason-field redaction, so admins see all requests (with reasons) while volunteers only see open or involved requests. (`src/server/services/entity/coverageService.ts`, `src/models/coverage.ts`, `src/models/api/coverage.ts`)
- Hydrates list items with shift/course context and embedded requesting/covering volunteers for UI display. (`src/server/services/entity/coverageService.ts`)
- Wired the list endpoint through the coverage router to accept cursor/limit inputs. (`src/server/api/routers/coverage-router.ts`)