### PR TITLE
automatic migration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,9 @@ import "./src/env.js";
 /** @type {import("next").NextConfig} */
 const nextConfig = {
   output: "standalone",
+  outputFileTracingIncludes: {
+    "/server.js": ["./src/server/db/migrations/**"],
+  },
 
   webpack(config, { isServer, dev }) {
     const fileLoaderRule = config.module.rules.find((rule) =>

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -1,10 +1,17 @@
 import { asFunction } from "awilix";
+import path from "node:path";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
 
 import { env } from "@/env";
 import * as schema from "@/server/db/schema";
+import {
+  MigrationsFolder,
+  MigrationsSchema,
+  MigrationsTable,
+} from "../../../drizzle.config";
 import { type NeuronContainer } from "../api/di-container";
 
 export type Drizzle = PostgresJsDatabase<typeof schema>;
@@ -15,13 +22,39 @@ export type Transaction = Parameters<TxCallback>[0];
  * Cache the database connection in development.
  * This avoids creating a new connection on every HMR * update.
  */
-const globalForDb = globalThis as unknown as { conn: postgres.Sql | undefined };
-const conn = globalForDb.conn ?? postgres(env.DATABASE_URL);
+const globalForDb = globalThis as unknown as {
+  conn: postgres.Sql | undefined;
+  migrationPromise: Promise<void> | undefined;
+};
+const conn =
+  globalForDb.conn ??
+  postgres(env.DATABASE_URL, {
+    onnotice: () => {}, // Silence postgres NOTICE spam (existing schema/table)
+  });
 
 if (env.NODE_ENV !== "production") globalForDb.conn = conn;
 
 // Export the database connection statically for better-auth
 export const db = drizzle(conn, { schema });
+
+async function runMigrations() {
+  const migrationsFolder = path.resolve(process.cwd(), MigrationsFolder);
+
+  try {
+    await migrate(db, {
+      migrationsFolder,
+      migrationsSchema: MigrationsSchema,
+      migrationsTable: MigrationsTable,
+    });
+  } catch (error) {
+    console.error("Failed to run database migrations", error);
+    process.exit(1);
+  }
+}
+
+const migrationPromise = globalForDb.migrationPromise ?? runMigrations();
+if (env.NODE_ENV !== "production") globalForDb.migrationPromise = migrationPromise;
+await migrationPromise;
 
 // Register the database in the DI container
 export function registerDb(container: NeuronContainer) {


### PR DESCRIPTION
Implemented automatic startup migrations and ensured standalone builds include migration assets.

Changes:
- Run Drizzle migrate() on server start using shared config, exit on failure, cache connection/migration in dev, and silence Postgres NOTICE logs.
- Resolve migration folder to an absolute path so standalone builds can locate meta/_journal.json.
- Add outputFileTracingIncludes for src/server/db/migrations/** to the standalone bundle.
