### PR TITLE
fix: prevent term-select from overriding current term on initial load

### DIFF
--- a/src/components/classes/list/class-list-view.tsx
+++ b/src/components/classes/list/class-list-view.tsx
@@ -112,6 +112,9 @@ export function ClassListView({ classId, setClassId }: ClassListViewProps) {
     if (queryTerm === "current") {
       if (!selectedTermId && currentTerm) {
         setSelectedTermId(currentTerm.id);
+      } else if (!selectedTermId && !isLoadingCurrentTerm && terms?.[0]) {
+        // No current term returned from backend; fall back to first term
+        setSelectedTermId(terms[0].id);
       }
       return;
     }

--- a/src/components/classes/list/components/term-select.tsx
+++ b/src/components/classes/list/components/term-select.tsx
@@ -33,10 +33,11 @@ export function TermSelect({
     isRefetching,
   } = clientApi.term.all.useQuery();
 
-  // If the current term is not in the list, select the first term
+  // If the selected term no longer exists (e.g. deleted), fall back to the first term.
+  // Only runs when selectedTermId is already set — initial selection is handled by class-list-view.
   useEffect(() => {
     const selectedTerm = terms?.find((t) => t.id === selectedTermId);
-    if (!selectedTerm && terms?.[0] && !isRefetching)
+    if (selectedTermId && !selectedTerm && terms?.[0] && !isRefetching)
       setSelectedTermId(terms[0].id);
   }, [terms, selectedTermId, setSelectedTermId]);
 


### PR DESCRIPTION
- Problem
    - On initial load, `term-select.tsx` had a fallback effect that ran when selectedTermId was null, racing against the current term fetch in class-list-view.tsx and overwriting it with terms[0].
- Fix
    - Added selectedTermId && guard so the fallback only runs when a previously-set term no longer exists (e.g. deleted), not on initial load.