### PR TITLE
refactor: replace custom hooks with usehooks-ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "superjson": "^2.2.6",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",
+    "usehooks-ts": "^3.1.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
+      usehooks-ts:
+        specifier: ^3.1.1
+        version: 3.1.1(react@19.2.3)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -7113,6 +7116,12 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  usehooks-ts@3.1.1:
+    resolution: {integrity: sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==}
+    engines: {node: '>=16.15.0'}
+    peerDependencies:
+      react: ^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -14745,6 +14754,11 @@ snapshots:
 
   use-sync-external-store@1.6.0(react@19.2.3):
     dependencies:
+      react: 19.2.3
+
+  usehooks-ts@3.1.1(react@19.2.3):
+    dependencies:
+      lodash.debounce: 4.0.8
       react: 19.2.3
 
   util-deprecate@1.0.2: {}

--- a/src/components/classes/edit/class-form-shell.tsx
+++ b/src/components/classes/edit/class-form-shell.tsx
@@ -1,7 +1,7 @@
 import { usePublicConfig } from "@/lib/public-config";
 import type { SingleClass } from "@/models/class";
 import type { Term } from "@/models/term";
-import { useEffect } from "react";
+import { useEventListener } from "usehooks-ts";
 import {
   PageLayout,
   PageLayoutContent,
@@ -40,16 +40,11 @@ export function ClassEditShell({
   });
 
   // Warn before navigating away during submission
-  useEffect(() => {
-    if (!isPending) return;
-
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+  useEventListener("beforeunload", (e: BeforeUnloadEvent) => {
+    if (isPending) {
       e.preventDefault();
-    };
-
-    window.addEventListener("beforeunload", handleBeforeUnload);
-    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
-  }, [isPending]);
+    }
+  });
 
   return (
     <ClassFormProvider

--- a/src/components/notifications/notification-inbox.tsx
+++ b/src/components/notifications/notification-inbox.tsx
@@ -26,6 +26,24 @@ export function NotificationInbox() {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [stuckHeader, setStuckHeader] = useState<string | null>(null);
 
+  const { data: unreadCount = 0 } = clientApi.notification.unreadCount.useQuery(
+    undefined,
+    {
+      refetchInterval: 30_000,
+    },
+  );
+
+  const { data, isLoading } = clientApi.notification.list.useQuery(
+    { limit: 20, ...getQueryParams(filter) },
+    { enabled: open },
+  );
+
+  const items = data?.items ?? [];
+  const groups = groupByDate(items);
+  const isArchivedView = filter === "archived";
+  const hasUnread = items.some((n) => !n.read);
+  const hasItems = items.length > 0;
+
   useEffect(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
@@ -53,25 +71,7 @@ export function NotificationInbox() {
 
     sentinels.forEach((s) => observer.observe(s));
     return () => observer.disconnect();
-  });
-
-  const { data: unreadCount = 0 } = clientApi.notification.unreadCount.useQuery(
-    undefined,
-    {
-      refetchInterval: 30_000,
-    },
-  );
-
-  const { data, isLoading } = clientApi.notification.list.useQuery(
-    { limit: 20, ...getQueryParams(filter) },
-    { enabled: open },
-  );
-
-  const items = data?.items ?? [];
-  const groups = groupByDate(items);
-  const isArchivedView = filter === "archived";
-  const hasUnread = items.some((n) => !n.read);
-  const hasItems = items.length > 0;
+  }, [groups.length]);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/src/components/page-layout.tsx
+++ b/src/components/page-layout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { useEventListener, useResizeObserver } from "usehooks-ts";
 
 import { Button } from "@/components/ui/button";
 import { TypographyPageTitle } from "@/components/ui/typography";
@@ -149,24 +150,12 @@ function PageLayoutHeader({
   const hideBorder =
     border === "never" || (border === "scroll" && !isPageScrolled);
 
-  const headerRef = React.useRef<HTMLElement | null>(null);
-  React.useLayoutEffect(() => {
-    const el = headerRef.current;
-    if (!el) return;
+  const headerRef = React.useRef<HTMLElement>(null!);
+  const { height = 0 } = useResizeObserver({ ref: headerRef, box: "border-box" });
 
-    const update = () => {
-      setHeaderHeight(el.offsetHeight);
-    };
-
-    update();
-
-    const ro = new ResizeObserver(update);
-    ro.observe(el);
-
-    return () => {
-      ro.disconnect();
-    };
-  }, [setHeaderHeight]);
+  React.useEffect(() => {
+    setHeaderHeight(height);
+  }, [height, setHeaderHeight]);
 
   return (
     <header
@@ -248,20 +237,22 @@ function PageLayoutContent({
   ...props
 }: React.ComponentProps<"main">) {
   const { setIsPageScrolled } = usePageLayout();
-  const mainRef = React.useRef<HTMLElement>(null);
+  const mainRef = React.useRef<HTMLElement>(null!);
+
+  useEventListener(
+    "scroll",
+    () => {
+      if (mainRef.current) {
+        setIsPageScrolled(mainRef.current.scrollTop > 0);
+      }
+    },
+    mainRef,
+  );
 
   React.useEffect(() => {
-    const element = mainRef.current;
-    if (!element) return;
-
-    const handleScroll = () => {
-      setIsPageScrolled(element.scrollTop > 0);
-    };
-
-    element.addEventListener("scroll", handleScroll);
-    handleScroll(); // Check initial state
-
-    return () => element.removeEventListener("scroll", handleScroll);
+    if (mainRef.current) {
+      setIsPageScrolled(mainRef.current.scrollTop > 0);
+    }
   }, [setIsPageScrolled]);
 
   return (

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -4,6 +4,7 @@ import BarsIcon from "@public/assets/icons/bars.svg";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
+import { useEventListener } from "usehooks-ts";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -106,20 +107,15 @@ function SidebarProvider({
   }, [isMobile, setOpen, setOpenMobile]);
 
   // Adds a keyboard shortcut to toggle the sidebar.
-  React.useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (
-        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
-      ) {
-        event.preventDefault();
-        toggleSidebar();
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [toggleSidebar]);
+  useEventListener("keydown", (event: KeyboardEvent) => {
+    if (
+      event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+      (event.metaKey || event.ctrlKey)
+    ) {
+      event.preventDefault();
+      toggleSidebar();
+    }
+  });
 
   // We add a state so that we can do data-state="expanded" or "collapsed".
   // This makes it easier to style the sidebar with Tailwind classes.

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -1,21 +1,7 @@
-import * as React from "react";
+import { useMediaQuery } from "usehooks-ts";
 
 const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
-    undefined,
-  );
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    };
-    mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    return () => mql.removeEventListener("change", onChange);
-  }, []);
-
-  return !!isMobile;
+  return useMediaQuery(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
 }


### PR DESCRIPTION
## Summary

- Add `usehooks-ts` dependency
- Replace custom `useIsMobile` implementation with `useMediaQuery` from usehooks-ts
- Replace manual `addEventListener`/`removeEventListener` patterns with `useEventListener` in `sidebar.tsx`, `class-form-shell.tsx`, and `page-layout.tsx`
- Replace manual `ResizeObserver` setup with `useResizeObserver` in `PageLayoutHeader`
- Fix missing dependency array on `useEffect` in `notification-inbox.tsx` (was running on every render; now runs when group count changes)

## Testing

- [ ] Sidebar keyboard shortcut (`Cmd/Ctrl+B`) still toggles sidebar
- [ ] Mobile responsive layout still collapses sidebar correctly
- [ ] Page header height updates correctly on resize
- [ ] Header border appears on scroll and hides at top
- [ ] Navigating away during class form submission still triggers the browser unload warning
- [ ] Notification inbox sticky group headers still highlight the correct section on scroll
- [ ] Notification unread count badge updates every 30s